### PR TITLE
Add `computeAmountIn` function and test coverage for `HybridCurve.sol`

### DIFF
--- a/contracts/libraries/MathUtils.sol
+++ b/contracts/libraries/MathUtils.sol
@@ -12,8 +12,6 @@ import "./SafeMath.sol";
  * @dev Originally https://github.com/saddle-finance/saddle-contract/blob/0b76f7fb519e34b878aa1d58cffc8d8dc0572c12/contracts/MathUtils.sol
  */
 library MathUtils {
-    using SafeMath for uint256;
-
     /**
      * @notice Compares a and b and returns true if the difference between a and b
      *         is less than 1 or equal to each other.
@@ -33,9 +31,11 @@ library MathUtils {
      * @return Difference between a and b
      */
     function difference(uint256 a, uint256 b) internal pure returns (uint256) {
-        if (a > b) {
-            return a.sub(b);
+        unchecked {
+            if (a > b) {
+                return a - b;
+            }
+            return b - a;
         }
-        return b.sub(a);
     }
 }

--- a/contracts/libraries/MathUtils.sol
+++ b/contracts/libraries/MathUtils.sol
@@ -2,8 +2,6 @@
 
 pragma solidity =0.8.4;
 
-import "./SafeMath.sol";
-
 /**
  * @title MathUtils library
  * @notice A library to be used in conjuction with SafeMath. Contains functions for calculating

--- a/contracts/pool/curves/HybridCurve.sol
+++ b/contracts/pool/curves/HybridCurve.sol
@@ -114,7 +114,7 @@ contract HybridCurve is IMirinCurve {
         uint8 tokenIn
     ) external pure override returns (uint256 amountIn) {
         require(amountOut > 0, "MIRIN: INSUFFICIENT_OUTPUT_AMOUNT");
-        require(reserve0 > 0 && reserve1 > 0, "MIRIN: INSUFFICIENT_LIQUIDITY");
+        require(reserve0 > 0 && reserve1 > 0 && (tokenIn != 0 ? reserve0 : reserve1) >= amountOut, "MIRIN: INSUFFICIENT_LIQUIDITY");
         require(swapFee <= MAX_SWAP_FEE, "MIRIN: INVALID_SWAP_FEE");
 
         (uint8 decimals0, uint8 decimals1, uint240 A) = decodeData(data);

--- a/contracts/pool/curves/HybridCurve.sol
+++ b/contracts/pool/curves/HybridCurve.sol
@@ -25,7 +25,10 @@ contract HybridCurve is IMirinCurve {
 
     // Constant values used in ramping A calculations
     uint256 private constant A_PRECISION = 100;
+
+    // Swap fee precision. Fees are in increments of 10 bps and cannot be higher than 10%.
     uint256 private constant SWAP_FEE_PRECISION = 1000;
+    uint256 private constant MAX_SWAP_FEE = 100;
 
     function canUpdateData(bytes32 oldData, bytes32 newData) external pure override returns (bool) {
         (uint8 oldDecimals0, uint8 oldDecimals1, ) = decodeData(oldData);
@@ -89,6 +92,10 @@ contract HybridCurve is IMirinCurve {
         uint8 swapFee,
         uint8 tokenIn
     ) external pure override returns (uint256 amountOut) {
+        require(amountIn > 0, "MIRIN: INSUFFICIENT_INPUT_AMOUNT");
+        require(reserve0 > 0 && reserve1 > 0, "MIRIN: INSUFFICIENT_LIQUIDITY");
+        require(swapFee <= MAX_SWAP_FEE, "MIRIN: INVALID_SWAP_FEE");
+
         (uint8 decimals0, uint8 decimals1, uint240 A) = decodeData(data);
         uint256[2] memory xp = _xp(reserve0, reserve1, decimals0, decimals1);
         amountIn = amountIn * 10**(POOL_PRECISION_DECIMALS - (tokenIn != 0 ? decimals1 : decimals0));
@@ -107,6 +114,10 @@ contract HybridCurve is IMirinCurve {
         uint8 swapFee,
         uint8 tokenIn
     ) external pure override returns (uint256 amountIn) {
+        require(amountOut > 0, "MIRIN: INSUFFICIENT_OUTPUT_AMOUNT");
+        require(reserve0 > 0 && reserve1 > 0, "MIRIN: INSUFFICIENT_LIQUIDITY");
+        require(swapFee <= MAX_SWAP_FEE, "MIRIN: INVALID_SWAP_FEE");
+
         (uint8 decimals0, uint8 decimals1, uint240 A) = decodeData(data);
         uint256[2] memory xp = _xp(reserve0, reserve1, decimals0, decimals1);
         amountOut = amountOut * 10**(POOL_PRECISION_DECIMALS - (tokenIn != 0 ? decimals0 : decimals1));

--- a/contracts/pool/curves/HybridCurve.sol
+++ b/contracts/pool/curves/HybridCurve.sol
@@ -230,7 +230,7 @@ contract HybridCurve is IMirinCurve {
         uint256 y = D;
         for (uint256 i = 0; i < MAX_LOOP_LIMIT; i++) {
             yPrev = y;
-            y = (y ** 2 + c) / (y * 2 + b.difference(D));
+            y = (y ** 2 + c) / (y * 2 + b - D);
             if (y.within1(yPrev)) {
                 return y;
             }

--- a/contracts/pool/curves/HybridCurve.sol
+++ b/contracts/pool/curves/HybridCurve.sol
@@ -3,7 +3,6 @@
 pragma solidity =0.8.4;
 
 import "../../interfaces/IMirinCurve.sol";
-import "../../libraries/SafeMath.sol";
 import "../../libraries/MathUtils.sol";
 
 /**
@@ -151,9 +150,7 @@ contract HybridCurve is IMirinCurve {
         uint256 nA = _A * 2;
 
         for (uint256 i = 0; i < MAX_LOOP_LIMIT; i++) {
-            uint256 dP = D;
-            dP = dP * D / (xp[0] * 2);
-            dP = dP * D / (xp[1] * 2);
+            uint256 dP = ((D**2) / (xp[0] * 2)) * D / (xp[1] * 2);
 
             prevD = D;
             D = (((nA * s / A_PRECISION) + (dP * 2)) * D) / (
@@ -187,7 +184,7 @@ contract HybridCurve is IMirinCurve {
         uint256 D = _getD(xp, _A);
         uint256 nA = 2 * _A;
 
-        uint256 c = (D**3 * A_PRECISION) / (nA * x * 4);
+        uint256 c = ((D**2) / (x * 2)) * D * A_PRECISION / (nA * 2);
         uint256 b = x + ((D * A_PRECISION) / nA);
 
         uint256 yPrev;

--- a/test/HybridCurve.test.js
+++ b/test/HybridCurve.test.js
@@ -73,47 +73,401 @@ describe("HybridCurve.sol test", function () {
     });
 
     describe("#computeAmountOut()", () => {
-        it("Succeeds with 18 decimal tokens", async function () {
-            // Swap 1e17 of 18 decimal token for 18 decimal token at varying A values
-            expect(
-                await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 100), 3, 0)
-            ).to.eq("94941617877778399");
+        describe("Pair of same decimals (18 decimals + 18 decimals pair)", () => {
+            it("Succeeds to calculate amount out", async function () {
+                // Swap 1e17 of 18 decimal token for 18 decimal token at varying A values
+                expect(
+                    await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 100), 3, 0)
+                ).to.eq("94941617877778399");
 
-            expect(
-                await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 5000), 3, 0)
-            ).to.eq("99503006734612204");
+                expect(
+                    await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 5000), 3, 0)
+                ).to.eq("99503006734612204");
 
-            expect(
-                await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 500000), 3, 0)
-            ).to.eq("99697986310591444");
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(1e18),
+                        String(1e18),
+                        buildData(18, 18, 500000),
+                        3,
+                        0
+                    )
+                ).to.eq("99697986310591444");
+            });
+
+            it("Succeeds with imbalanced pool setup (sparse -> abundant)", async function () {
+                // Swap 1e17 of sparse 18 decimal token for abundant 18 decimal token at varying A values
+                // At low A value we expect the trade to happen similar to a regular sushi swap pair
+                // As A is increased, the imbalance of the pool becomes less weighted.
+                // At high A, we expect the trade to happen as if the pool is balanced.
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 100),
+                        3,
+                        0
+                    )
+                ).to.eq("122411604069641073");
+
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 5000),
+                        3,
+                        0
+                    )
+                ).to.eq("100547177117692933");
+
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 500000),
+                        3,
+                        0
+                    )
+                ).to.eq("99708627684742534");
+            });
+
+            it("Succeeds with imbalanced pool setup (abundant -> sparse)", async function () {
+                // Swap 1e17 of abundant 18 decimal token for sparse 18 decimal token at varying A values
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 100),
+                        3,
+                        1
+                    )
+                ).to.eq("81114740843624621");
+
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 5000),
+                        3,
+                        1
+                    )
+                ).to.eq("98855096633898709");
+
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 500000),
+                        3,
+                        1
+                    )
+                ).to.eq("99691322596171150");
+            });
         });
 
-        it("Succeeds with tokens of different decimals", async function () {
-            // Swap 1e17 of 18 decimal token for 6 decimal token at varying A values
-            expect(
-                await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 100), 3, 0)
-            ).to.eq("94941");
+        describe("Pair of different decimals (18 decimals + 6 decimals pair)", () => {
+            it("Succeeds to calculate amount out", async function () {
+                // Swap 1e17 of 18 decimal token for 6 decimal token at varying A values
+                expect(
+                    await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 100), 3, 0)
+                ).to.eq("94941");
 
-            expect(
-                await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 5000), 3, 0)
-            ).to.eq("99503");
+                expect(
+                    await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 5000), 3, 0)
+                ).to.eq("99503");
 
-            expect(
-                await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 500000), 3, 0)
-            ).to.eq("99697");
+                expect(
+                    await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 500000), 3, 0)
+                ).to.eq("99697");
 
-            // Swap 1e5 of 6 decimal token for 18 decimal token at varying A values
-            expect(
-                await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 100), 3, 1)
-            ).to.eq("94941617877778399");
+                // Swap 1e5 of 6 decimal token for 18 decimal token at varying A values
+                expect(
+                    await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 100), 3, 1)
+                ).to.eq("94941617877778399");
 
-            expect(
-                await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 5000), 3, 1)
-            ).to.eq("99503006734612204");
+                expect(
+                    await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 5000), 3, 1)
+                ).to.eq("99503006734612204");
 
-            expect(
-                await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 500000), 3, 1)
-            ).to.eq("99697986310591444");
+                expect(
+                    await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 500000), 3, 1)
+                ).to.eq("99697986310591444");
+            });
+
+            it("Succeeds with imbalanced pool setup (sparse -> abundant)", async function () {
+                // Swap 1e17 of sparse 18 decimal token for abundant 6 decimal token at varying A values
+                expect(
+                    await test.computeAmountOut(String(1e17), String(80e18), String(120e6), buildData(18, 6, 100), 3, 0)
+                ).to.eq("122411");
+
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e6),
+                        buildData(18, 6, 5000),
+                        3,
+                        0
+                    )
+                ).to.eq("100547");
+
+                expect(
+                    await test.computeAmountOut(
+                        String(1e17),
+                        String(80e18),
+                        String(120e6),
+                        buildData(18, 6, 500000),
+                        3,
+                        0
+                    )
+                ).to.eq("99708");
+            });
+
+            it("Succeeds with imbalanced pool setup (abundant -> sparse)", async function () {
+                // Swap 1e17 of abundant 6 decimal token for sparse 18 decimal token at varying A values
+                expect(
+                    await test.computeAmountOut(String(1e5), String(80e18), String(120e6), buildData(18, 6, 100), 3, 1)
+                ).to.eq("81114740843624621");
+
+                expect(
+                    await test.computeAmountOut(String(1e5), String(80e18), String(120e6), buildData(18, 6, 5000), 3, 1)
+                ).to.eq("98855096633898709");
+
+                expect(
+                    await test.computeAmountOut(
+                        String(1e5),
+                        String(80e18),
+                        String(120e6),
+                        buildData(18, 6, 500000),
+                        3,
+                        1
+                    )
+                ).to.eq("99691322596171150");
+            });
+        });
+    });
+
+    describe("#computeAmountIn()", () => {
+        describe("Pair of same decimals (18 decimals + 18 decimals pair)", () => {
+            it("Succeeds to calculate amount in", async () => {
+                // Compute how much input is required at varying A values
+                expect(
+                    await test.computeAmountIn(
+                        "94941617877778399",
+                        String(1e18),
+                        String(1e18),
+                        buildData(18, 18, 100),
+                        3,
+                        0
+                    )
+                ).to.eq("99999999999999999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "99503006734612204",
+                        String(1e18),
+                        String(1e18),
+                        buildData(18, 18, 5000),
+                        3,
+                        0
+                    )
+                ).to.eq("99999999999999999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "99697986310591444",
+                        String(1e18),
+                        String(1e18),
+                        buildData(18, 18, 500000),
+                        3,
+                        0
+                    )
+                ).to.eq("99999999999999999");
+            });
+
+            it("Succeeds with imbalanced pool setup (sparse -> abundant)", async function () {
+                expect(
+                    await test.computeAmountIn(
+                        "122411604069641073",
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 100),
+                        3,
+                        0
+                    )
+                ).to.eq("99999999999999999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "100547177117692933",
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 5000),
+                        3,
+                        0
+                    )
+                ).to.eq("99999999999999999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "99708627684742534",
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 500000),
+                        3,
+                        0
+                    )
+                ).to.eq("99999999999999999");
+            });
+
+            it("Succeeds with imbalanced pool setup (abundant -> sparse)", async function () {
+                expect(
+                    await test.computeAmountIn(
+                        "81114740843624621",
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 100),
+                        3,
+                        1
+                    )
+                ).to.eq("99999999999999999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "98855096633898709",
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 5000),
+                        3,
+                        1
+                    )
+                ).to.eq("99999999999999999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "99691322596171150",
+                        String(80e18),
+                        String(120e18),
+                        buildData(18, 18, 500000),
+                        3,
+                        1
+                    )
+                ).to.eq("99999999999999999");
+            });
+        });
+
+        describe("Pair of different decimals (18 decimals + 6 decimals pair)", function () {
+            it("Succeeds with tokens of different decimals", async function () {
+                // Compute amount in required to get 6 decimal tokens at varying A values
+                expect(
+                    await test.computeAmountIn("94941", String(1e18), String(1e6), buildData(18, 6, 100), 3, 0)
+                ).to.eq("99999316426437242");
+
+                expect(
+                    await test.computeAmountIn("99503", String(1e18), String(1e6), buildData(18, 6, 5000), 3, 0)
+                ).to.eq("99999993218090731");
+
+                expect(
+                    await test.computeAmountIn("99697", String(1e18), String(1e6), buildData(18, 6, 500000), 3, 0)
+                ).to.eq("99999010681206893");
+
+                // Compute amount in required to get 18 decimal tokens at varying A values
+                expect(
+                    await test.computeAmountIn(
+                        "94941617877778399",
+                        String(1e18),
+                        String(1e6),
+                        buildData(18, 6, 100),
+                        3,
+                        1
+                    )
+                ).to.eq("99999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "99503006734612204",
+                        String(1e18),
+                        String(1e6),
+                        buildData(18, 6, 5000),
+                        3,
+                        1
+                    )
+                ).to.eq("99999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "99697986310591444",
+                        String(1e18),
+                        String(1e6),
+                        buildData(18, 6, 500000),
+                        3,
+                        1
+                    )
+                ).to.eq("99999");
+            });
+
+            it("Succeeds with imbalanced pool setup (sparse -> abundant)", async function () {
+                expect(
+                    await test.computeAmountIn(String(1e5), String(80e18), String(120e6), buildData(18, 6, 100), 3, 0)
+                ).to.eq("81682719428770142");
+
+                expect(
+                    await test.computeAmountIn(String(1e5), String(80e18), String(120e6), buildData(18, 6, 5000), 3, 0)
+                ).to.eq("99455787264111639");
+
+                expect(
+                    await test.computeAmountIn(
+                        String(1e5),
+                        String(80e18),
+                        String(120e6),
+                        buildData(18, 6, 500000),
+                        3,
+                        0
+                    )
+                ).to.eq("100292223848503994");
+            });
+
+            it("Succeeds with imbalanced pool setup (abundant -> sparse)", async function () {
+                expect(
+                    await test.computeAmountIn(
+                        "81114740843624621",
+                        String(80e18),
+                        String(120e6),
+                        buildData(18, 6, 100),
+                        3,
+                        1
+                    )
+                ).to.eq("99999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "98855096633898709",
+                        String(80e18),
+                        String(120e6),
+                        buildData(18, 6, 5000),
+                        3,
+                        1
+                    )
+                ).to.eq("99999");
+
+                expect(
+                    await test.computeAmountIn(
+                        "99691322596171150",
+                        String(80e18),
+                        String(120e6),
+                        buildData(18, 6, 500000),
+                        3,
+                        1
+                    )
+                ).to.eq("99999");
+            });
         });
     });
 });

--- a/test/HybridCurve.test.js
+++ b/test/HybridCurve.test.js
@@ -63,7 +63,7 @@ describe("HybridCurve.sol test", function () {
         });
 
         it("Succeeds when data is valid", async function () {
-            for (let n = 0; n < 100; n++) {
+            for (let n = 0; n < 1000; n++) {
                 let data = buildRandData();
                 let expected = decodeData(data);
                 let result = await test.decodeData(data);
@@ -75,21 +75,20 @@ describe("HybridCurve.sol test", function () {
     describe("#computeAmountOut()", () => {
         it("Succeeds with 18 decimal tokens", async function () {
             // Swap 1e17 of 18 decimal token for 18 decimal token at varying A values
-
             expect(
                 await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 100), 3, 0)
-            ).to.eq("94941617877778400");
+            ).to.eq("94941617877778399");
 
             expect(
                 await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 5000), 3, 0)
-            ).to.eq("99503006734612205");
+            ).to.eq("99503006734612204");
 
             expect(
                 await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 500000), 3, 0)
-            ).to.eq("99697986310591445");
+            ).to.eq("99697986310591444");
         });
 
-        it("Succeeds with different decimal tokens", async function () {
+        it("Succeeds with tokens of different decimals", async function () {
             // Swap 1e17 of 18 decimal token for 6 decimal token at varying A values
             expect(
                 await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 100), 3, 0)
@@ -106,15 +105,15 @@ describe("HybridCurve.sol test", function () {
             // Swap 1e5 of 6 decimal token for 18 decimal token at varying A values
             expect(
                 await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 100), 3, 1)
-            ).to.eq("94941617877778400");
+            ).to.eq("94941617877778399");
 
             expect(
                 await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 5000), 3, 1)
-            ).to.eq("99503006734612205");
+            ).to.eq("99503006734612204");
 
             expect(
                 await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 500000), 3, 1)
-            ).to.eq("99697986310591445");
+            ).to.eq("99697986310591444");
         });
     });
 });

--- a/test/HybridCurve.test.js
+++ b/test/HybridCurve.test.js
@@ -1,16 +1,13 @@
-const { expect, assert } = require("chai");
+const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { BigNumber, utils } = require("ethers");
-const { Decimal } = require("decimal.js");
-const Decimal18 = Decimal.clone({ precision: 18 });
-const Decimal40 = Decimal.clone({ precision: 40 });
 
 function randDecimals() {
-    return Math.floor(Math.random() * 18) + 1; // [1, 18]
+    return Math.floor(Math.random() * 19); // [0, 18]
 }
 
 function randA() {
-    return Math.floor(Math.random() * 5000000) + 1; // [1, 5000000]
+    return Math.floor(Math.random() * 500000) + 100; // [100, 500099]
 }
 
 function buildRandData() {
@@ -21,8 +18,8 @@ function buildRandData() {
 }
 
 function decodeData(data) {
-    let d0 = BigNumber.from(utils.hexDataSlice(data, 0, 1));
-    let d1 = BigNumber.from(utils.hexDataSlice(data, 1, 2));
+    let d0 = BigNumber.from(utils.hexDataSlice(data, 0, 1)).toNumber();
+    let d1 = BigNumber.from(utils.hexDataSlice(data, 1, 2)).toNumber();
     let a = BigNumber.from(utils.hexDataSlice(data, 2));
     return [d0, d1, a];
 }
@@ -43,7 +40,7 @@ function buildData(decimals0, decimals1, A) {
     return utils.hexConcat([d0, d1, a]);
 }
 
-describe("HybridCurve test", function () {
+describe("HybridCurve.sol test", function () {
     let HC, test;
     let n, js, con, data;
     const BASE = BigNumber.from(10).pow(18);
@@ -53,342 +50,71 @@ describe("HybridCurve test", function () {
         test = await HC.deploy();
     });
 
-    it("Should fail if decodeData is not valid", async function () {
-        data = buildData(19, 1, 50000);
-        await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
+    describe("#decodeData()", () => {
+        it("Reverts when data is not valid", async function () {
+            data = buildData(19, 1, 50000);
+            await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
 
-        data = buildData(18, 19, 50000);
-        await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
+            data = buildData(18, 19, 50000);
+            await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
 
-        data = buildData(18, 18, 0);
-        await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
-    });
+            data = buildData(18, 18, 99);
+            await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
+        });
 
-    it("Should decode Data which is valid", async function () {
-        for (let n = 0; n < 100; n++) {
-            let data = buildRandData();
-            let expected = decodeData(data);
-            let result = await test.decodeData(data);
-
-            expect(result[0]).to.eq(expected[0]); // decimals0
-            expect(result[1]).to.eq(expected[1]); // decimals1
-            expect(result[2]).to.eq(expected[2]); // A
-        }
-    });
-    /**
-    it("Should fail in some cases in computeAmountOut function", async function () {
-        randParams();
-        aIn = 0;
-        data = getData();
-        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INSUFFICIENT_INPUT_AMOUNT"
-        );
-
-        randParams();
-        rIn = 0;
-        data = getData();
-        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INSUFFICIENT_LIQUIDITY"
-        );
-        randParams();
-        rOut = 0;
-        data = getData();
-        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INSUFFICIENT_LIQUIDITY"
-        );
-
-        randParams();
-        swapFee = 101;
-        data = getData();
-        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INVALID_SWAP_FEE"
-        );
-    });
-
-    it("Should work tokenIn is not 0 in computeAmountOut function", async function () {
-        let Out1, Out2, r0, r1, tempW;
-        n = 0;
-        while (n < 10) {
-            randParams();
-            if (BigNumber.from(aIn).lte(rIn.div(2)) && BigNumber.from(aIn).lte(rOut.div(2))) {
-                data = getData();
-                r0 = rIn;
-                r1 = rOut;
-
-                Out1 = await test.computeAmountOut(aIn, r0, r1, data, swapFee, 0);
-
-                tempW = wI;
-                wI = wO;
-                wO = tempW;
-
-                data = getData();
-                Out2 = await test.computeAmountOut(aIn, r1, r0, data, swapFee, 1);
-
-                expect(Out1).to.be.eq(Out2);
-                n++;
+        it("Succeeds when data is valid", async function () {
+            for (let n = 0; n < 100; n++) {
+                let data = buildRandData();
+                let expected = decodeData(data);
+                let result = await test.decodeData(data);
+                expect(result).to.deep.eq(expected);
             }
-        }
+        });
     });
 
-    it("Should compute amoutOut value as precisely as possible", async function () {
-        n = 0;
-        while (n < 2000) {
-            randParams();
-            data = getData();
-            if (BigNumber.from(aIn).gt(rIn.div(2))) {
-                await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-                    "MIRIN: ERR_MAX_IN_RATIO"
-                );
-            } else {
-                Out = await test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0);
-                let jsBase = Decimal18(rIn.toString()).div(rIn.add(aIn.mul(1000 - swapFee).div(1000)).toString());
+    describe("#computeAmountOut()", () => {
+        it("Succeeds with 18 decimal tokens", async function () {
+            // Swap 1e17 of 18 decimal token for 18 decimal token at varying A values
 
-                let jsPower = jsBase.pow(Decimal(wI).div(wO)).mul(BASE.toString()).floor();
-                js = rOut.mul(BASE.sub(jsPower.toString())).div(BASE);
-                let js1 = rOut
-                    .mul(BASE.sub(jsPower.sub(2).toString()))
-                    .div(BASE)
-                    .add(2);
-                let js2 = rOut
-                    .mul(BASE.sub(jsPower.add(2).toString()))
-                    .div(BASE)
-                    .sub(2);
+            expect(
+                await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 100), 3, 0)
+            ).to.eq("94941617877778400");
 
-                if (js.isZero()) {
-                    //about 20k times in 100k trials
-                    if (!Out.isZero()) {
-                        expect(Out).to.be.lte(js1); //about 0.5k in 100k
-                    }
-                } else if (jsBase.eq(1)) {
-                    //never happen in 100k
-                    expect(Out.toNumber()).to.be.eq(0);
-                } else if (Math.floor((Math.abs(Out - js) / js) * 1000000) > 1) {
-                    //about 10k in 100k
-                    expect(Out).to.be.lte(js1);
-                    expect(Out).to.be.gte(js2);
-                } else {
-                    expect(Math.floor((Math.abs(Out - js) / js) * 1000000)).to.be.lte(1); //about 70k in 100k
-                }
+            expect(
+                await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 5000), 3, 0)
+            ).to.eq("99503006734612205");
 
-                if (!js.isZero()) n++;
-            }
-        }
+            expect(
+                await test.computeAmountOut(String(1e17), String(1e18), String(1e18), buildData(18, 18, 500000), 3, 0)
+            ).to.eq("99697986310591445");
+        });
+
+        it("Succeeds with different decimal tokens", async function () {
+            // Swap 1e17 of 18 decimal token for 6 decimal token at varying A values
+            expect(
+                await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 100), 3, 0)
+            ).to.eq("94941");
+
+            expect(
+                await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 5000), 3, 0)
+            ).to.eq("99503");
+
+            expect(
+                await test.computeAmountOut(String(1e17), String(1e18), String(1e6), buildData(18, 6, 500000), 3, 0)
+            ).to.eq("99697");
+
+            // Swap 1e5 of 6 decimal token for 18 decimal token at varying A values
+            expect(
+                await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 100), 3, 1)
+            ).to.eq("94941617877778400");
+
+            expect(
+                await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 5000), 3, 1)
+            ).to.eq("99503006734612205");
+
+            expect(
+                await test.computeAmountOut(String(1e5), String(1e18), String(1e6), buildData(18, 6, 500000), 3, 1)
+            ).to.eq("99697986310591445");
+        });
     });
-
-    it("Should fail in some cases in computeAmountIn function", async function () {
-        randParams();
-        aOut = 0;
-        data = getData();
-        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INSUFFICIENT_INPUT_AMOUNT"
-        );
-
-        randParams();
-        rIn = 0;
-        data = getData();
-        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INSUFFICIENT_LIQUIDITY"
-        );
-        randParams();
-        rOut = 0;
-        data = getData();
-        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INSUFFICIENT_LIQUIDITY"
-        );
-
-        randParams();
-        swapFee = 101;
-        data = getData();
-        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-            "MIRIN: INVALID_SWAP_FEE"
-        );
-    });
-
-    it("Should work tokenIn is not 0 in computeAmountIn function", async function () {
-        let In1, In2, r0, r1, tempW;
-        n = 0;
-        while (n < 10) {
-            randParams();
-            if (BigNumber.from(aOut).lte(rIn.div(3)) && BigNumber.from(aOut).lte(rOut.div(3))) {
-                data = getData();
-                r0 = rIn;
-                r1 = rOut;
-
-                In1 = await test.computeAmountIn(aOut, r0, r1, data, swapFee, 0);
-
-                tempW = wI;
-                wI = wO;
-                wO = tempW;
-
-                data = getData();
-                In2 = await test.computeAmountIn(aOut, r1, r0, data, swapFee, 1);
-
-                expect(In1).to.be.eq(In2);
-                n++;
-            }
-        }
-    });
-
-    it("Should compute amoutIn value as precisely as possible", async function () {
-        n = 0;
-        while (n < 2000) {
-            randParams();
-            data = getData();
-            if (BigNumber.from(aOut).gt(BigNumber.from(rOut).div(3))) {
-                await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
-                    "MIRIN: ERR_MAX_OUT_RATIO"
-                );
-            } else {
-                In = await test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0);
-
-                let jsBase = Decimal(rOut.toString())
-                    .div(rOut.sub(aOut).toString())
-                    .mul(BASE.toString())
-                    .floor()
-                    .div(BASE.toString());
-
-                let jsPower = jsBase.pow(Decimal(wO).div(wI)).mul(BASE.toString()).floor();
-                let jsPower1 = jsBase.add(Decimal("1e-18")).pow(Decimal(wO).div(wI)).mul(BASE.toString()).floor();
-                let jsPower2 = jsBase.sub(Decimal("1e-18")).pow(Decimal(wO).div(wI)).mul(BASE.toString()).floor();
-                js = rIn.mul(BigNumber.from(jsPower.toHex()).sub(BASE)).div(BASE.sub(BASE.mul(swapFee).div(1000)));
-                let js1 = rIn
-                    .mul(BigNumber.from(jsPower1.add(2).toHex()).sub(BASE))
-                    .div(BASE.sub(BASE.mul(swapFee).div(1000)))
-                    .add(2);
-                let js2 = rIn
-                    .mul(BigNumber.from(jsPower2.sub(2).toHex()).sub(BASE))
-                    .div(BASE.sub(BASE.mul(swapFee).div(1000)))
-                    .sub(2);
-
-                if (js.isZero()) {
-                    //about 23k times in 100k trials
-                    if (!In.isZero()) {
-                        //about 0.5k in 100k
-                        expect(In).to.be.lte(js1);
-                    }
-                } else if (jsBase.eq(1)) {
-                    //never happen in 100k
-                    expect(In.toNumber()).to.be.eq(0);
-                } else if (Math.floor((Math.abs(In - js) / js) * 1000000) > 1) {
-                    //about 8k in 100k
-                    expect(In).to.be.lte(js1);
-                    expect(In).to.be.gte(js2);
-                } else {
-                    expect(Math.floor((Math.abs(In - js) / js) * 1000000)).to.be.lte(1); //about 70k in 100k
-                }
-
-                if (!js.isZero()) n++;
-            }
-        }
-    });
-});
-
-describe("ConstantMeanCurve additional Test", function () {
-    let CMC, test;
-    let n, js, con, data;
-    const BASE = BigNumber.from(10).pow(18);
-
-    before(async function () {
-        CMC = await ethers.getContractFactory("ConstantMeanCurve");
-        test = await CMC.deploy();
-    });
-
-    it("Should return false whatever data is in canUpdateData fn", async function () {
-        let p1 = utils.hexZeroPad(BigNumber.from(13579).toHexString(), 32);
-        let p2 = utils.formatBytes32String("Hello, world!");
-
-        expect(await test.canUpdateData(p1, p2)).to.be.false;
-    });
-
-    it("Should return false if data is not valid through isValidData fn", async function () {
-        wO = 0;
-        wI = 100;
-        data = getData();
-        expect(await test.isValidData(data)).to.be.false;
-
-        wO = 100;
-        wI = 0;
-        data = getData();
-        expect(await test.isValidData(data)).to.be.false;
-    });
-
-    it("Should pass true if data is valid through isValidData fn", async function () {
-        n = 0;
-        while (n < 100) {
-            randParams();
-            data = getData();
-            expect(await test.isValidData(data)).to.be.true;
-            n++;
-        }
-    });
-
-    it("Should compute price as precisely as possible", async function () {
-        let r0, r1, w0, w1;
-        n = 0;
-        while (n < 100) {
-            randParams();
-            data = getData();
-            r0 = rIn;
-            r1 = rOut;
-            w0 = wI;
-            w1 = wO;
-
-            con = await test.computePrice(r0, r1, data, 0);
-            js = r1.mul(BigNumber.from(2).pow(104)).mul(w0).div(r0).div(w1);
-            expect(con).to.eq(js);
-            n++;
-        }
-        n = 0;
-        while (n < 100) {
-            randParams();
-            data = getData();
-            r0 = rIn;
-            r1 = rOut;
-            w0 = wI;
-            w1 = wO;
-
-            con = await test.computePrice(r0, r1, data, 1);
-            js = r0.mul(BigNumber.from(2).pow(104)).mul(w1).div(r1).div(w0);
-            expect(con).to.eq(js);
-            n++;
-        }
-    });
-
-    it("Should compute Liquidity as precisely as possible", async function () {
-        const Fixed1 = BigNumber.from(2).pow(127);
-        let r0, r1, w0, w1;
-        n = 0;
-
-        while (n < 700) {
-            randParamsforCL();
-            r0 = rIn;
-            r1 = rOut;
-            w0 = wI;
-            w1 = wO;
-            data = getData();
-
-            let lnLiq = Decimal40(r0.toHexString())
-                .ln()
-                .mul(w0)
-                .add(Decimal40(r1.toHexString()).ln().mul(w1))
-                .div(w0 + w1)
-                .mul(Fixed1.toHexString())
-                .floor();
-
-            js = lnLiq.div(Fixed1.toHexString()).exp().floor();
-            let js1 = js.mul(1 + Math.pow(10, -8)).floor();
-            let js2 = js.mul(1 - Math.pow(10, -8)).floor();
-            con = await test.computeLiquidity(r0, r1, data);
-
-            if (con.gte(Math.pow(10, 10))) {
-                expect(con).to.be.lte(BigNumber.from(js1.toHex()));
-                expect(con).to.be.gte(BigNumber.from(js2.toHex()));
-            } else {
-                expect(con).to.be.lte(BigNumber.from(js1.add(10).toHex()));
-                expect(con).to.be.gte(BigNumber.from(js2.sub(10).toHex()));
-            }
-            n++;
-        }
-    });
-**/
 });

--- a/test/HybridCurve.test.js
+++ b/test/HybridCurve.test.js
@@ -1,0 +1,394 @@
+const { expect, assert } = require("chai");
+const { ethers } = require("hardhat");
+const { BigNumber, utils } = require("ethers");
+const { Decimal } = require("decimal.js");
+const Decimal18 = Decimal.clone({ precision: 18 });
+const Decimal40 = Decimal.clone({ precision: 40 });
+
+function randDecimals() {
+    return Math.floor(Math.random() * 18) + 1; // [1, 18]
+}
+
+function randA() {
+    return Math.floor(Math.random() * 5000000) + 1; // [1, 5000000]
+}
+
+function buildRandData() {
+    let decimals0 = randDecimals();
+    let decimals1 = randDecimals();
+    let A = randA();
+    return buildData(decimals0, decimals1, A);
+}
+
+function decodeData(data) {
+    let d0 = BigNumber.from(utils.hexDataSlice(data, 0, 1));
+    let d1 = BigNumber.from(utils.hexDataSlice(data, 1, 2));
+    let a = BigNumber.from(utils.hexDataSlice(data, 2));
+    return [d0, d1, a];
+}
+
+function buildData(decimals0, decimals1, A) {
+    let d0 = BigNumber.from(decimals0).toHexString();
+    d0 = utils.hexZeroPad(d0, 32);
+    d0 = utils.hexDataSlice(d0, 31); // uint8 size
+
+    let d1 = BigNumber.from(decimals1).toHexString();
+    d1 = utils.hexZeroPad(d1, 32);
+    d1 = utils.hexDataSlice(d1, 31); // uint8 size
+
+    let a = BigNumber.from(A).toHexString();
+    a = utils.hexZeroPad(a, 32);
+    a = utils.hexDataSlice(a, 2); // uint240 size
+
+    return utils.hexConcat([d0, d1, a]);
+}
+
+describe("HybridCurve test", function () {
+    let HC, test;
+    let n, js, con, data;
+    const BASE = BigNumber.from(10).pow(18);
+
+    before(async function () {
+        HC = await ethers.getContractFactory("HybridCurve");
+        test = await HC.deploy();
+    });
+
+    it("Should fail if decodeData is not valid", async function () {
+        data = buildData(19, 1, 50000);
+        await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
+
+        data = buildData(18, 19, 50000);
+        await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
+
+        data = buildData(18, 18, 0);
+        await expect(test.decodeData(data)).to.be.revertedWith("MIRIN: INVALID_DATA");
+    });
+
+    it("Should decode Data which is valid", async function () {
+        for (let n = 0; n < 100; n++) {
+            let data = buildRandData();
+            let expected = decodeData(data);
+            let result = await test.decodeData(data);
+
+            expect(result[0]).to.eq(expected[0]); // decimals0
+            expect(result[1]).to.eq(expected[1]); // decimals1
+            expect(result[2]).to.eq(expected[2]); // A
+        }
+    });
+    /**
+    it("Should fail in some cases in computeAmountOut function", async function () {
+        randParams();
+        aIn = 0;
+        data = getData();
+        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INSUFFICIENT_INPUT_AMOUNT"
+        );
+
+        randParams();
+        rIn = 0;
+        data = getData();
+        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INSUFFICIENT_LIQUIDITY"
+        );
+        randParams();
+        rOut = 0;
+        data = getData();
+        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INSUFFICIENT_LIQUIDITY"
+        );
+
+        randParams();
+        swapFee = 101;
+        data = getData();
+        await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INVALID_SWAP_FEE"
+        );
+    });
+
+    it("Should work tokenIn is not 0 in computeAmountOut function", async function () {
+        let Out1, Out2, r0, r1, tempW;
+        n = 0;
+        while (n < 10) {
+            randParams();
+            if (BigNumber.from(aIn).lte(rIn.div(2)) && BigNumber.from(aIn).lte(rOut.div(2))) {
+                data = getData();
+                r0 = rIn;
+                r1 = rOut;
+
+                Out1 = await test.computeAmountOut(aIn, r0, r1, data, swapFee, 0);
+
+                tempW = wI;
+                wI = wO;
+                wO = tempW;
+
+                data = getData();
+                Out2 = await test.computeAmountOut(aIn, r1, r0, data, swapFee, 1);
+
+                expect(Out1).to.be.eq(Out2);
+                n++;
+            }
+        }
+    });
+
+    it("Should compute amoutOut value as precisely as possible", async function () {
+        n = 0;
+        while (n < 2000) {
+            randParams();
+            data = getData();
+            if (BigNumber.from(aIn).gt(rIn.div(2))) {
+                await expect(test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+                    "MIRIN: ERR_MAX_IN_RATIO"
+                );
+            } else {
+                Out = await test.computeAmountOut(aIn, rIn, rOut, data, swapFee, 0);
+                let jsBase = Decimal18(rIn.toString()).div(rIn.add(aIn.mul(1000 - swapFee).div(1000)).toString());
+
+                let jsPower = jsBase.pow(Decimal(wI).div(wO)).mul(BASE.toString()).floor();
+                js = rOut.mul(BASE.sub(jsPower.toString())).div(BASE);
+                let js1 = rOut
+                    .mul(BASE.sub(jsPower.sub(2).toString()))
+                    .div(BASE)
+                    .add(2);
+                let js2 = rOut
+                    .mul(BASE.sub(jsPower.add(2).toString()))
+                    .div(BASE)
+                    .sub(2);
+
+                if (js.isZero()) {
+                    //about 20k times in 100k trials
+                    if (!Out.isZero()) {
+                        expect(Out).to.be.lte(js1); //about 0.5k in 100k
+                    }
+                } else if (jsBase.eq(1)) {
+                    //never happen in 100k
+                    expect(Out.toNumber()).to.be.eq(0);
+                } else if (Math.floor((Math.abs(Out - js) / js) * 1000000) > 1) {
+                    //about 10k in 100k
+                    expect(Out).to.be.lte(js1);
+                    expect(Out).to.be.gte(js2);
+                } else {
+                    expect(Math.floor((Math.abs(Out - js) / js) * 1000000)).to.be.lte(1); //about 70k in 100k
+                }
+
+                if (!js.isZero()) n++;
+            }
+        }
+    });
+
+    it("Should fail in some cases in computeAmountIn function", async function () {
+        randParams();
+        aOut = 0;
+        data = getData();
+        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INSUFFICIENT_INPUT_AMOUNT"
+        );
+
+        randParams();
+        rIn = 0;
+        data = getData();
+        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INSUFFICIENT_LIQUIDITY"
+        );
+        randParams();
+        rOut = 0;
+        data = getData();
+        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INSUFFICIENT_LIQUIDITY"
+        );
+
+        randParams();
+        swapFee = 101;
+        data = getData();
+        await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+            "MIRIN: INVALID_SWAP_FEE"
+        );
+    });
+
+    it("Should work tokenIn is not 0 in computeAmountIn function", async function () {
+        let In1, In2, r0, r1, tempW;
+        n = 0;
+        while (n < 10) {
+            randParams();
+            if (BigNumber.from(aOut).lte(rIn.div(3)) && BigNumber.from(aOut).lte(rOut.div(3))) {
+                data = getData();
+                r0 = rIn;
+                r1 = rOut;
+
+                In1 = await test.computeAmountIn(aOut, r0, r1, data, swapFee, 0);
+
+                tempW = wI;
+                wI = wO;
+                wO = tempW;
+
+                data = getData();
+                In2 = await test.computeAmountIn(aOut, r1, r0, data, swapFee, 1);
+
+                expect(In1).to.be.eq(In2);
+                n++;
+            }
+        }
+    });
+
+    it("Should compute amoutIn value as precisely as possible", async function () {
+        n = 0;
+        while (n < 2000) {
+            randParams();
+            data = getData();
+            if (BigNumber.from(aOut).gt(BigNumber.from(rOut).div(3))) {
+                await expect(test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0)).to.be.revertedWith(
+                    "MIRIN: ERR_MAX_OUT_RATIO"
+                );
+            } else {
+                In = await test.computeAmountIn(aOut, rIn, rOut, data, swapFee, 0);
+
+                let jsBase = Decimal(rOut.toString())
+                    .div(rOut.sub(aOut).toString())
+                    .mul(BASE.toString())
+                    .floor()
+                    .div(BASE.toString());
+
+                let jsPower = jsBase.pow(Decimal(wO).div(wI)).mul(BASE.toString()).floor();
+                let jsPower1 = jsBase.add(Decimal("1e-18")).pow(Decimal(wO).div(wI)).mul(BASE.toString()).floor();
+                let jsPower2 = jsBase.sub(Decimal("1e-18")).pow(Decimal(wO).div(wI)).mul(BASE.toString()).floor();
+                js = rIn.mul(BigNumber.from(jsPower.toHex()).sub(BASE)).div(BASE.sub(BASE.mul(swapFee).div(1000)));
+                let js1 = rIn
+                    .mul(BigNumber.from(jsPower1.add(2).toHex()).sub(BASE))
+                    .div(BASE.sub(BASE.mul(swapFee).div(1000)))
+                    .add(2);
+                let js2 = rIn
+                    .mul(BigNumber.from(jsPower2.sub(2).toHex()).sub(BASE))
+                    .div(BASE.sub(BASE.mul(swapFee).div(1000)))
+                    .sub(2);
+
+                if (js.isZero()) {
+                    //about 23k times in 100k trials
+                    if (!In.isZero()) {
+                        //about 0.5k in 100k
+                        expect(In).to.be.lte(js1);
+                    }
+                } else if (jsBase.eq(1)) {
+                    //never happen in 100k
+                    expect(In.toNumber()).to.be.eq(0);
+                } else if (Math.floor((Math.abs(In - js) / js) * 1000000) > 1) {
+                    //about 8k in 100k
+                    expect(In).to.be.lte(js1);
+                    expect(In).to.be.gte(js2);
+                } else {
+                    expect(Math.floor((Math.abs(In - js) / js) * 1000000)).to.be.lte(1); //about 70k in 100k
+                }
+
+                if (!js.isZero()) n++;
+            }
+        }
+    });
+});
+
+describe("ConstantMeanCurve additional Test", function () {
+    let CMC, test;
+    let n, js, con, data;
+    const BASE = BigNumber.from(10).pow(18);
+
+    before(async function () {
+        CMC = await ethers.getContractFactory("ConstantMeanCurve");
+        test = await CMC.deploy();
+    });
+
+    it("Should return false whatever data is in canUpdateData fn", async function () {
+        let p1 = utils.hexZeroPad(BigNumber.from(13579).toHexString(), 32);
+        let p2 = utils.formatBytes32String("Hello, world!");
+
+        expect(await test.canUpdateData(p1, p2)).to.be.false;
+    });
+
+    it("Should return false if data is not valid through isValidData fn", async function () {
+        wO = 0;
+        wI = 100;
+        data = getData();
+        expect(await test.isValidData(data)).to.be.false;
+
+        wO = 100;
+        wI = 0;
+        data = getData();
+        expect(await test.isValidData(data)).to.be.false;
+    });
+
+    it("Should pass true if data is valid through isValidData fn", async function () {
+        n = 0;
+        while (n < 100) {
+            randParams();
+            data = getData();
+            expect(await test.isValidData(data)).to.be.true;
+            n++;
+        }
+    });
+
+    it("Should compute price as precisely as possible", async function () {
+        let r0, r1, w0, w1;
+        n = 0;
+        while (n < 100) {
+            randParams();
+            data = getData();
+            r0 = rIn;
+            r1 = rOut;
+            w0 = wI;
+            w1 = wO;
+
+            con = await test.computePrice(r0, r1, data, 0);
+            js = r1.mul(BigNumber.from(2).pow(104)).mul(w0).div(r0).div(w1);
+            expect(con).to.eq(js);
+            n++;
+        }
+        n = 0;
+        while (n < 100) {
+            randParams();
+            data = getData();
+            r0 = rIn;
+            r1 = rOut;
+            w0 = wI;
+            w1 = wO;
+
+            con = await test.computePrice(r0, r1, data, 1);
+            js = r0.mul(BigNumber.from(2).pow(104)).mul(w1).div(r1).div(w0);
+            expect(con).to.eq(js);
+            n++;
+        }
+    });
+
+    it("Should compute Liquidity as precisely as possible", async function () {
+        const Fixed1 = BigNumber.from(2).pow(127);
+        let r0, r1, w0, w1;
+        n = 0;
+
+        while (n < 700) {
+            randParamsforCL();
+            r0 = rIn;
+            r1 = rOut;
+            w0 = wI;
+            w1 = wO;
+            data = getData();
+
+            let lnLiq = Decimal40(r0.toHexString())
+                .ln()
+                .mul(w0)
+                .add(Decimal40(r1.toHexString()).ln().mul(w1))
+                .div(w0 + w1)
+                .mul(Fixed1.toHexString())
+                .floor();
+
+            js = lnLiq.div(Fixed1.toHexString()).exp().floor();
+            let js1 = js.mul(1 + Math.pow(10, -8)).floor();
+            let js2 = js.mul(1 - Math.pow(10, -8)).floor();
+            con = await test.computeLiquidity(r0, r1, data);
+
+            if (con.gte(Math.pow(10, 10))) {
+                expect(con).to.be.lte(BigNumber.from(js1.toHex()));
+                expect(con).to.be.gte(BigNumber.from(js2.toHex()));
+            } else {
+                expect(con).to.be.lte(BigNumber.from(js1.add(10).toHex()));
+                expect(con).to.be.gte(BigNumber.from(js2.sub(10).toHex()));
+            }
+            n++;
+        }
+    });
+**/
+});


### PR DESCRIPTION
Scope of this PR:
- Further optimize `HybridCruve.sol` for 2 token pairs
- Add test coverage for existing functions
- Add `computeAmountIn()` function